### PR TITLE
Improve compatibility with other frameworks and future OMF.

### DIFF
--- a/init.fish
+++ b/init.fish
@@ -14,11 +14,6 @@ function init --on-event init_emacs
     end
   end
 
-  function __add_functions_to_path
-    set emacs_functions $OMF_PATH/pkg/emacs/functions
-    set fish_function_path $emacs_functions $fish_function_path
-  end
-
   if not set -q __emacs
     set __emacs (which emacs)
   end
@@ -29,10 +24,8 @@ function init --on-event init_emacs
 
   if test "$__emacs_version" -gt 23
     __set_editor
-    __add_functions_to_path
   end
 
   functions -e __major_version
   functions -e __set_editor
-  functions -e __add_functions_to_path
 end

--- a/init.fish
+++ b/init.fish
@@ -36,7 +36,3 @@ function init --on-event init_emacs
   functions -e __set_editor
   functions -e __add_functions_to_path
 end
-
-function emacs
-  __launch_emacs $argv --no-wait
-end

--- a/init.fish
+++ b/init.fish
@@ -1,31 +1,29 @@
-function init --on-event init_emacs
-  function __major_version
-    if test -n "$argv"
-      set -l full_metadata (eval $argv --version)
-      set -l full_version (echo $full_metadata | grep -o "[0-9]\+.[0-9]\+.[0-9]\+")
-      set -l major_version (echo $full_version | sed  "s/\..*//")
-      echo $major_version
-    end
+function __major_version
+  if test -n "$argv"
+    set -l full_metadata (eval $argv --version)
+    set -l full_version (echo $full_metadata | grep -o "[0-9]\+.[0-9]\+.[0-9]\+")
+    set -l major_version (echo $full_version | sed  "s/\..*//")
+    echo $major_version
   end
-
-  function __set_editor
-    if not set -q EDITOR
-      set -gx EDITOR emacs
-    end
-  end
-
-  if not set -q __emacs
-    set __emacs (which emacs)
-  end
-
-  if not set -q __emacs_version
-    set __emacs_version (__major_version $__emacs)
-  end
-
-  if test "$__emacs_version" -gt 23
-    __set_editor
-  end
-
-  functions -e __major_version
-  functions -e __set_editor
 end
+
+function __set_editor
+  if not set -q EDITOR
+    set -gx EDITOR emacs
+  end
+end
+
+if not set -q __emacs
+  set __emacs (which emacs)
+end
+
+if not set -q __emacs_version
+  set __emacs_version (__major_version $__emacs)
+end
+
+if test "$__emacs_version" -gt 23
+  __set_editor
+end
+
+functions -e __major_version
+functions -e __set_editor


### PR DESCRIPTION
- Move initialization to `init.fish`.
- Don't mess with function path, it's already autoloaded.
- Initialize immediately, rather than waiting for an event.
