### PR TITLE
 get it working with fish 2.7.1 and emacs 26.1

### DIFF
--- a/init.fish
+++ b/init.fish
@@ -1,8 +1,7 @@
 function __major_version
   if test -n "$argv"
     set -l full_metadata (eval $argv --version)
-    set -l full_version (echo $full_metadata | grep -o "[0-9]\+.[0-9]\+.[0-9]\+")
-    set -l major_version (echo $full_version | sed  "s/\..*//")
+    set -l major_version (echo $full_metadata | sed -r  's/^[^0-9]*([0-9]+).*/\1/')
     echo $major_version
   end
 end

--- a/init.fish
+++ b/init.fish
@@ -1,7 +1,7 @@
 function __major_version
   if test -n "$argv"
     set -l full_metadata (eval $argv --version)
-    set -l major_version (echo $full_metadata | sed -r  's/^[^0-9]*([0-9]+).*/\1/')
+    set -l major_version (echo $full_metadata | sed -E  's/^[^0-9]*([0-9]+).*/\1/')
     echo $major_version
   end
 end


### PR DESCRIPTION
With emacs 26.1 and fish 2.7.1 I get the error:

```shell
test returned eval errors:
        invalid integer ''
```