### PR TITLE
Check emacs command exists

### DIFF
--- a/init.fish
+++ b/init.fish
@@ -1,3 +1,7 @@
+if not command -sq emacs
+  exit 0
+end
+
 function __major_version
   if test -n "$argv"
     set -l full_metadata (eval $argv --version)


### PR DESCRIPTION
If emacs is not installed, ```Invalid argument: ''``` error occurred 
because ```test "" -gt 23``` is invalid.
This PR fixes this error.

