### PR TITLE
Add waiting function.

### DIFF
--- a/functions/ew.fish
+++ b/functions/ew.fish
@@ -1,0 +1,3 @@
+function ew --description 'Launch an emacs buffer that waits until done.'
+    __launch_emacs $argv # e uses --no-wait, but we want to wait.
+end


### PR DESCRIPTION
added `ew` for **E**macs **W**ait.
So I can use `e`, `ec`, and `ew` to drive Emacs around with a fish.